### PR TITLE
 Replace internal ALB with service discovery

### DIFF
--- a/mu.yml
+++ b/mu.yml
@@ -3,3 +3,4 @@ service:
   desiredCount: 3
   maxSize: 6
   port: 3000
+  discoveryTTL: 0

--- a/mu.yml
+++ b/mu.yml
@@ -3,4 +3,4 @@ service:
   desiredCount: 3
   maxSize: 6
   port: 3000
-  discoveryTTL: 0
+  discoveryTTL: 30

--- a/mu.yml
+++ b/mu.yml
@@ -3,4 +3,4 @@ service:
   desiredCount: 3
   maxSize: 6
   port: 3000
-  discoveryTTL: 30
+  discoveryTTL: 5

--- a/mu.yml
+++ b/mu.yml
@@ -3,14 +3,3 @@ service:
   desiredCount: 3
   maxSize: 6
   port: 3000
-  priority: 50
-  pathPatterns:
-  - /*
-  networkMode: awsvpc
-parameters:
-  '${env:MU_NAMESPACE}-service-ecsdemo-nodejs-acceptance':
-    ElbHttpListenerArn:
-        ${env:MU_NAMESPACE}-loadbalancer-acceptance-BackendLBHttpListenerArn
-  '${env:MU_NAMESPACE}-service-ecsdemo-nodejs-production':
-    ElbHttpListenerArn:
-        ${env:MU_NAMESPACE}-loadbalancer-production-BackendLBHttpListenerArn


### PR DESCRIPTION
Leverage new feature of mu 1.5.1 to support AWS Service Discovery instead of using an internal ALB